### PR TITLE
Landing gear hints

### DIFF
--- a/nasal/LandingGear.nas
+++ b/nasal/LandingGear.nas
@@ -41,10 +41,27 @@ var LandingGear = {
     # @param bool onGround - If true then aircraft start on the ground, otherwise in air
     # @return int - nuber of found wheels/landing gears
     #
-    recognizeGears: func(onGround) {
+    recognizeGears: func(onGround, addonHints) {
         me.resetLandingWithNoGearRecognized();
 
         me.gearIndexes = [];
+
+        if (addonHints != nil) {
+            # We use landing-gear hints directly from the model.
+            # logprint(MY_LOG_LEVEL, "Logbook Add-on - hints node detected");
+            me.loopThroughHints(addonHints, func(index) {
+                #logprint(MY_LOG_LEVEL, "Logbook Add-on - HINT CALLBACK: ", index);
+                append(me.gearIndexes, index);
+            });
+
+            if (size(me.gearIndexes) > 0) {
+                # at least one gear hint was found
+                logprint(MY_LOG_LEVEL, "Logbook Add-on - using landing gear hints provided by model");
+                return size(me.gearIndexes);
+            } else {
+                logprint(LOG_ALERT, "Logbook Add-on: hints node present, but no landing gear hints detected");
+            }
+        }
 
         if (onGround) {
             # We are on the ground, so we can count the gears from "/gear/gear[n]/wow" property
@@ -218,6 +235,20 @@ var LandingGear = {
             if (wow != nil and wow.getValue()) {
                 callback(gear.getIndex());
             }
+        }
+    },
+
+    #
+    # Loop through all landing gear hint properties
+    #
+    # @param hintsNode - valid reference to "/sim/addon-hints/Logbook" node
+    # @param func callback - function called with a value of a found landing-gear-idx child node
+    # @return void
+    #
+    loopThroughHints: func(hintsNode, callback) {
+        foreach (var hint; hintsNode.getChildren("landing-gear-idx")) {
+            var value = hint.getValue();
+            callback(value);
         }
     },
 

--- a/nasal/Logbook.nas
+++ b/nasal/Logbook.nas
@@ -35,6 +35,8 @@ var Logbook = {
         me.startOdometer = 0.0; # distance at takeoff
         me.onGround      = getprop("/sim/presets/onground"); # 1 - on ground, 0 - in air
         logprint(MY_LOG_LEVEL, "Logbook Add-on - init onGround = ", me.onGround);
+        me.addonHints    = props.globals.getNode("/sim/addon-hints/Logbook");
+        if (me.addonHints != nil) {logprint(MY_LOG_LEVEL, "Logbook Add-on - init HINTS NODE = ", me.addonHints.getName());}
         me.initAltAglFt  = Logbook.ALT_AGL_FT_THRESHOLD;
         me.isSimPaused   = false;
         me.isReplayMode  = false;
@@ -146,7 +148,7 @@ var Logbook = {
     # @return void
     #
     initLogbook: func() {
-        me.landingGear.recognizeGears(me.onGround);
+        me.landingGear.recognizeGears(me.onGround, me.addonHints);
 
         me.initAltAglThreshold();
 
@@ -315,7 +317,7 @@ var Logbook = {
 
             # We know it's landed, so reset some states like detect the landing gear again in case it will takeoff again.
             me.onGround = true;
-            me.landingGear.recognizeGears(me.onGround);
+            me.landingGear.recognizeGears(me.onGround, me.addonHints);
             me.initAltAglThreshold();
         }
 

--- a/nasal/Logbook.nas
+++ b/nasal/Logbook.nas
@@ -82,7 +82,7 @@ var Logbook = {
 
             # User probably used the "Location" -> "in air" or change airport even during a flight
             if (!oldOnGround and me.onGround) {
-                # I was in the air, now I'm in the ground, try to stop logging
+                # I was in the air, now I'm on the ground, try to stop logging
                 me.stopLogging(false);
             }
 


### PR DESCRIPTION
I implemented an optional mechanism allowing aircraft developers to give hints to Logbook about which landing gear indexes to use for landing/crash detection.

Some aircraft, especially gliders with in-line gear config, lean to the side on the ground and confuse the add-on. 
In such cases it is now possible to specify hints:
```
        <sim>
                ...
                <addon-hints>
                        <Logbook>
                                <landing-gear-idx type="int">0</landing-gear-idx>
                                <landing-gear-idx type="int">1</landing-gear-idx>
                        </Logbook>
                </addon-hints>
                ...
        </sim>
```
and avoid the confusion.

Tested with ASK21-jsb. Branch logbook-hints in my fork.

Hoping you will find it useful :-)
