### PR TITLE
Modified getStartAirport() for multi-legs flights

### DIFF
--- a/nasal/Logbook.nas
+++ b/nasal/Logbook.nas
@@ -128,16 +128,17 @@ var Logbook = {
     # @return string - ICAO code or empty
     #
     getStartAirport: func() {
-        var startAirportIcao = getprop("/sim/presets/airport-id");
 
-        # Note: when user will use --lat, --lon then startAirportIcao is an empty string
+        # Try to get nearest airport
+        var maxDistance = me.spaceShuttle.isLaunched()
+            ? 9000  # Max distance to 9 km, neede by Space Shuttle startd from Launch Pad 39A
+            : 6000; # Use max distance as 6000 m (Schiphol need 6 km)
+
+        var startAirportIcao = me.airport.getNearestIcao(maxDistance);
+
         if (startAirportIcao == "" or startAirportIcao == nil) {
-            # Try to get nearest airport
-            var maxDistance = me.spaceShuttle.isLaunched()
-                ? 9000  # Max distance to 9 km, neede by Space Shuttle startd from Launch Pad 39A
-                : 6000; # Use max distance as 6000 m (Schiphol need 6 km)
-
-            return me.airport.getNearestIcao(maxDistance);
+            # Note: when user will use --lat, --lon then startAirportIcao is an empty string
+            startAirportIcao = getprop("/sim/presets/airport-id");
         }
 
         return startAirportIcao;

--- a/nasal/Logbook.nas
+++ b/nasal/Logbook.nas
@@ -134,14 +134,7 @@ var Logbook = {
             ? 9000  # Max distance to 9 km, neede by Space Shuttle startd from Launch Pad 39A
             : 6000; # Use max distance as 6000 m (Schiphol need 6 km)
 
-        var startAirportIcao = me.airport.getNearestIcao(maxDistance);
-
-        if (startAirportIcao == "" or startAirportIcao == nil) {
-            # Note: when user will use --lat, --lon then startAirportIcao is an empty string
-            startAirportIcao = getprop("/sim/presets/airport-id");
-        }
-
-        return startAirportIcao;
+        return me.airport.getNearestIcao(maxDistance);
     },
 
     #


### PR DESCRIPTION
If you're travelling to multiple destinations in the same FlightGear session the current implementation uses as starting airport always the one available when FlightGear started.

For example, for the following flight plan:

- Honolulu - San Francisco
- San Francisco - Ontario
- Ontario - Las vegas

instead of having the following codes in the log file:

```
PHNL,KSFO
KSFO,KONT
KONT,KLAS
```

the current implementation reports the following:

```
PHNL,KSFO
PHNL,KONT
PHNL,KLAS
```

With the proposed pull request the `getStartAirport()` function grabs the airport from current location first, falling back to the first airport if it does not succeed. In this way if you land to an airport and depart in a few minutes without exiting FlightGear, the `from` field t is set with the airport you just departed from.